### PR TITLE
flamingo: use specific idProduct for usb paths

### DIFF
--- a/aosp_d2203.mk
+++ b/aosp_d2203.mk
@@ -52,4 +52,5 @@ PRODUCT_AAPT_PREBUILT_DPI := hdpi
 PRODUCT_AAPT_PREF_CONFIG := hdpi
 
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.sf.lcd_density=240
+    ro.sf.lcd_density=240 \
+    ro.usb.pid_suffix=1BC


### PR DESCRIPTION
from 18.5.C.0.19

Signed-off-by: David Viteri <davidteri91@gmail.com>