### PR TITLE
flamingo: props for sensors

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -16,6 +16,8 @@ include device/sony/yukon/BoardConfig.mk
 
 TARGET_RECOVERY_FSTAB = device/sony/flamingo/rootdir/fstab.yukon
 
+TARGET_SYSTEM_PROP += device/sony/flamingo/system.prop
+
 TARGET_BOOTLOADER_BOARD_NAME := D2203
 
 BOARD_SYSTEMIMAGE_PARTITION_SIZE   := 1782579200

--- a/system.prop
+++ b/system.prop
@@ -1,0 +1,24 @@
+# Disable invalid sensors
+ro.qualcomm.sensors.cmc=false
+ro.qualcomm.sensors.georv=false
+ro.qualcomm.sensors.pam=false
+ro.qualcomm.sensors.pedometer=false
+ro.qualcomm.sensors.qmd=false
+ro.qualcomm.sensors.scrn_ortn=false
+ro.qualcomm.sensors.smd=false
+ro.qc.sdk.sensors.gestures=false
+
+# Sensor debugging
+# Valid settings (and presumably what they mean):
+#   0      - off
+#   1      - all the things
+#   V or v - verbose
+#   D or d - debug
+#   E or e - errors
+#   W or w - warnings
+#   I or i - info
+
+persist.debug.sensors.hal=0
+debug.qualcomm.sns.daemon=0
+debug.qualcomm.sns.hal=0
+debug.qualcomm.sns.libsensor1=0


### PR DESCRIPTION
flamingo is a simple device so disable the sensors it actually doesn't have.
Also the logspam from the sensors can actually crash apps like CPU-Z which
try to read all the sensors at once. Disable all sensors logspam (it's OK,
we know the sensors are working).

Signed-off-by: Adam Farden <adam@farden.cz>